### PR TITLE
feat: set HTTP user agent

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -188,7 +188,13 @@ async fn main() {
 
     let Cli { options, revisions } = Cli::parse();
 
-    let client = Client::builder().gzip(true).build().unwrap();
+    static APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
+
+    let client = Client::builder()
+        .gzip(true)
+        .user_agent(APP_USER_AGENT)
+        .build()
+        .unwrap();
 
     for rev_ref in revisions {
         get_artifacts_for_revision(&client, &options, &rev_ref).await


### PR DESCRIPTION
To comply with Treeherder upstream's [request](https://treeherder.readthedocs.io/accessing_data.html#user-agents) that clients set user agents explicitly:

> When interacting with Treeherder's API, you must set an appropriate User Agent header (rather than relying on the defaults of your language/library) so that we can more easily track API feature usage, as well as accidental abuse. …

The text goes on to say that default user agents will be rejected, but we haven't been, for some reason. Still, let's be a good citizen; let's make it obvious to Mozilla who's doing what.